### PR TITLE
Fix test failures by isolating config file path

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -1,10 +1,16 @@
 package main
 
 import (
+	"path/filepath"
 	"testing"
 )
 
 func TestLoadConfig(t *testing.T) {
+	// Set config path to a non-existent file to ensure tests only use env vars
+	// This prevents the test from accidentally reading a config.yaml file
+	// that might exist in the executable directory
+	t.Setenv("UMAMI_MCP_CONFIG", filepath.Join(t.TempDir(), "non-existent-config.yaml"))
+
 	tests := []struct {
 		name    string
 		envVars map[string]string
@@ -36,6 +42,12 @@ func TestLoadConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Clear all env vars first to ensure clean test state
+			t.Setenv("UMAMI_URL", "")
+			t.Setenv("UMAMI_USERNAME", "")
+			t.Setenv("UMAMI_PASSWORD", "")
+			
+			// Set test-specific env vars
 			for k, v := range tt.envVars {
 				t.Setenv(k, v)
 			}


### PR DESCRIPTION
The tests were failing because LoadConfig() was trying to read a config.yaml file from the executable directory, which behaves differently across OS platforms. This fix ensures tests only use environment variables by setting the config path to a non-existent file in a temporary directory.