### PR TITLE
fix: Smithery deployment compliance

### DIFF
--- a/http.go
+++ b/http.go
@@ -23,8 +23,18 @@ func NewHTTPHandler() *HTTPHandler {
 	return &HTTPHandler{}
 }
 
+func setCORS(w http.ResponseWriter) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, Mcp-Session-Id")
+	w.Header().Set("Access-Control-Expose-Headers", "Mcp-Session-Id")
+}
+
 func (h *HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	setCORS(w)
+
 	switch r.Method {
+	case http.MethodOptions:
+		w.WriteHeader(http.StatusNoContent)
 	case http.MethodPost:
 		h.handlePost(w, r)
 	case http.MethodGet:

--- a/http_test.go
+++ b/http_test.go
@@ -76,7 +76,7 @@ func TestHTTP_Initialize(t *testing.T) {
 	if !ok {
 		t.Fatal("Result is not a map")
 	}
-	if result["protocolVersion"] != "2024-11-05" {
+	if result["protocolVersion"] != "2025-03-26" {
 		t.Errorf("Wrong protocol version: %v", result["protocolVersion"])
 	}
 }
@@ -163,6 +163,23 @@ func TestHTTP_DeleteSession(t *testing.T) {
 
 	if w2.Code != http.StatusNotFound {
 		t.Errorf("Expected 404 after delete, got %d", w2.Code)
+	}
+}
+
+func TestHTTP_OptionsPreflight(t *testing.T) {
+	handler := NewHTTPHandler()
+	req := httptest.NewRequest(http.MethodOptions, "/mcp", http.NoBody)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected 204, got %d", w.Code)
+	}
+	if w.Header().Get("Access-Control-Allow-Origin") == "" {
+		t.Error("Missing Access-Control-Allow-Origin header")
+	}
+	if w.Header().Get("Access-Control-Expose-Headers") == "" {
+		t.Error("Missing Access-Control-Expose-Headers header")
 	}
 }
 

--- a/mcp.go
+++ b/mcp.go
@@ -97,7 +97,7 @@ func (s *MCPServer) send(resp Response) {
 
 func (s *MCPServer) processInitialize() any {
 	return map[string]any{
-		"protocolVersion": "2024-11-05",
+		"protocolVersion": "2025-03-26",
 		"serverInfo": map[string]string{
 			"name":    "umami-mcp",
 			"version": version,

--- a/mcp_test.go
+++ b/mcp_test.go
@@ -22,7 +22,7 @@ func TestMCPServer_HandleInitialize(t *testing.T) {
 	if !ok {
 		t.Fatal("Result is not a map")
 	}
-	if result["protocolVersion"] != "2024-11-05" {
+	if result["protocolVersion"] != "2025-03-26" {
 		t.Errorf("Wrong protocol version: %v", result["protocolVersion"])
 	}
 

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,3 +1,4 @@
+runtime: container
 startCommand:
   type: http
   configSchema:


### PR DESCRIPTION
## Summary

- Add required `runtime: container` field to `smithery.yaml` (Smithery docs say it's required)
- Add CORS headers (`Access-Control-Allow-Origin`, `Access-Control-Allow-Headers`, `Access-Control-Expose-Headers`) and OPTIONS preflight handling — required by Smithery's gateway for browser-based clients
- Update MCP protocol version from `2024-11-05` to `2025-03-26` (the revision that defines Streamable HTTP transport)

## Test plan

- [x] All tests pass locally (`go test ./...`)
- [x] New test for OPTIONS preflight with CORS headers
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)