### PR TITLE
feat: add server card endpoint for Smithery discovery

### DIFF
--- a/http.go
+++ b/http.go
@@ -156,6 +156,38 @@ func generateSessionID() string {
 	return hex.EncodeToString(b)
 }
 
+func (h *HTTPHandler) handleServerCard(w http.ResponseWriter, _ *http.Request) {
+	toolsData, _ := toolsFS.ReadFile("tools.json")
+	promptsData, _ := promptsFS.ReadFile("prompts.json")
+
+	var tools []json.RawMessage
+	_ = json.Unmarshal(toolsData, &tools)
+
+	var prompts []json.RawMessage
+	_ = json.Unmarshal(promptsData, &prompts)
+
+	card := map[string]any{
+		"serverInfo": map[string]string{
+			"name":    "umami-mcp",
+			"version": version,
+		},
+		"tools":   tools,
+		"prompts": prompts,
+		"resources": []map[string]any{
+			{
+				"uri":         "umami://websites",
+				"name":        "Website List",
+				"description": "List of all websites configured in Umami",
+				"mimeType":    "application/json",
+			},
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	data, _ := json.Marshal(card)
+	_, _ = w.Write(data)
+}
+
 func writeJSONRPCError(w http.ResponseWriter, id any, rpcErr *Error) {
 	resp := Response{JSONRPC: "2.0", ID: id, Error: rpcErr}
 	w.Header().Set("Content-Type", "application/json")

--- a/main.go
+++ b/main.go
@@ -51,9 +51,13 @@ func main() {
 		if port == "" {
 			port = "8080"
 		}
+		handler := NewHTTPHandler()
+		mux := http.NewServeMux()
+		mux.Handle("/mcp", handler)
+		mux.HandleFunc("/.well-known/mcp/server-card.json", handler.handleServerCard)
 		srv := &http.Server{
 			Addr:              ":" + port,
-			Handler:           NewHTTPHandler(),
+			Handler:           mux,
 			ReadHeaderTimeout: 10 * time.Second,
 		}
 		log.Printf("Starting HTTP transport on :%s", port)


### PR DESCRIPTION
## Summary
- Add `/.well-known/mcp/server-card.json` endpoint so Smithery's scanner can discover server capabilities without authenticating
- Route `/mcp` and the server card endpoint via `http.ServeMux`
- Add `TestHTTP_ServerCard` covering status code, content type, and payload structure

## Test plan
- [x] `go test ./...` passes
- [x] `go build` compiles cleanly
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)