### PR TITLE
feat: accept ISO 8601 dates to prevent LLM timestamp errors

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -39,6 +39,9 @@ func (s *MCPServer) execGetStats(args json.RawMessage) (any, *Error) {
 		return nil, &Error{Code: -32602, Message: "Invalid arguments"}
 	}
 
+	params.StartDate = normalizeDate(params.StartDate)
+	params.EndDate = normalizeDate(params.EndDate)
+
 	stats, err := s.client.GetStats(params.WebsiteID, params.StartDate, params.EndDate)
 	if err != nil {
 		return nil, &Error{Code: -32603, Message: fmt.Sprintf("Failed to get stats: %v", err)}
@@ -68,6 +71,9 @@ func (s *MCPServer) execGetPageViews(args json.RawMessage) (any, *Error) {
 	if params.Unit == "" {
 		params.Unit = "day"
 	}
+
+	params.StartDate = normalizeDate(params.StartDate)
+	params.EndDate = normalizeDate(params.EndDate)
 
 	pageviews, err := s.client.GetPageViews(params.WebsiteID, params.StartDate, params.EndDate, params.Unit)
 	if err != nil {
@@ -99,6 +105,9 @@ func (s *MCPServer) execGetMetrics(args json.RawMessage) (any, *Error) {
 	if params.Limit == 0 {
 		params.Limit = 10
 	}
+
+	params.StartDate = normalizeDate(params.StartDate)
+	params.EndDate = normalizeDate(params.EndDate)
 
 	metrics, err := s.client.GetMetrics(
 		params.WebsiteID, params.StartDate, params.EndDate, params.MetricType, params.Limit,

--- a/normalize.go
+++ b/normalize.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// normalizeDate converts ISO 8601 date strings to Unix millisecond timestamps.
+// If the input is already a numeric timestamp, it is returned as-is.
+// Supported formats: "2026-03-23", "2026-03-23T14:30:00Z", "2026-03-23T14:30:00+01:00"
+func normalizeDate(input string) string {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return input
+	}
+
+	// Already a number (timestamp) — return as-is
+	if _, err := strconv.ParseInt(input, 10, 64); err == nil {
+		return input
+	}
+
+	// Try parsing as ISO 8601 formats
+	formats := []string{
+		"2006-01-02T15:04:05Z07:00", // full ISO with timezone
+		"2006-01-02T15:04:05Z",      // UTC
+		"2006-01-02T15:04:05",       // no timezone (assume UTC)
+		"2006-01-02",                // date only (assume start of day UTC)
+	}
+
+	for _, format := range formats {
+		if t, err := time.Parse(format, input); err == nil {
+			return fmt.Sprintf("%d", t.UnixMilli())
+		}
+	}
+
+	// Nothing matched — return original, let Umami API handle the error
+	return input
+}

--- a/normalize_test.go
+++ b/normalize_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestNormalizeDate_Timestamps(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"1774220400000", "1774220400000"},
+		{"1742688000000", "1742688000000"},
+		{"0", "0"},
+	}
+
+	for _, tt := range tests {
+		result := normalizeDate(tt.input)
+		if result != tt.expected {
+			t.Errorf("normalizeDate(%q) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestNormalizeDate_ISODates(t *testing.T) {
+	tests := []struct {
+		input string
+		year  int
+		month time.Month
+		day   int
+	}{
+		{"2026-03-23", 2026, time.March, 23},
+		{"2025-01-01", 2025, time.January, 1},
+		{"2026-12-31", 2026, time.December, 31},
+	}
+
+	for _, tt := range tests {
+		result := normalizeDate(tt.input)
+		ms, err := strconv.ParseInt(result, 10, 64)
+		if err != nil {
+			t.Errorf("normalizeDate(%q) = %q, expected numeric timestamp", tt.input, result)
+			continue
+		}
+
+		parsed := time.UnixMilli(ms).UTC()
+		if parsed.Year() != tt.year || parsed.Month() != tt.month || parsed.Day() != tt.day {
+			t.Errorf("normalizeDate(%q) = %s, want %d-%02d-%02d",
+				tt.input, parsed.Format("2006-01-02"), tt.year, tt.month, tt.day)
+		}
+	}
+}
+
+func TestNormalizeDate_ISODateTime(t *testing.T) {
+	tests := []struct {
+		input string
+		hour  int
+		min   int
+	}{
+		{"2026-03-23T14:30:00Z", 14, 30},
+		{"2026-03-23T00:00:00Z", 0, 0},
+		{"2026-03-23T23:59:59Z", 23, 59},
+	}
+
+	for _, tt := range tests {
+		result := normalizeDate(tt.input)
+		ms, err := strconv.ParseInt(result, 10, 64)
+		if err != nil {
+			t.Errorf("normalizeDate(%q) = %q, expected numeric timestamp", tt.input, result)
+			continue
+		}
+
+		parsed := time.UnixMilli(ms).UTC()
+		if parsed.Hour() != tt.hour || parsed.Minute() != tt.min {
+			t.Errorf("normalizeDate(%q) time = %02d:%02d, want %02d:%02d",
+				tt.input, parsed.Hour(), parsed.Minute(), tt.hour, tt.min)
+		}
+	}
+}
+
+func TestNormalizeDate_ISOWithTimezone(t *testing.T) {
+	result := normalizeDate("2026-03-23T14:30:00+02:00")
+	ms, err := strconv.ParseInt(result, 10, 64)
+	if err != nil {
+		t.Fatalf("normalizeDate returned non-numeric: %q", result)
+	}
+
+	parsed := time.UnixMilli(ms).UTC()
+	// 14:30 +02:00 = 12:30 UTC
+	if parsed.Hour() != 12 || parsed.Minute() != 30 {
+		t.Errorf("expected 12:30 UTC, got %02d:%02d", parsed.Hour(), parsed.Minute())
+	}
+}
+
+func TestNormalizeDate_EmptyAndInvalid(t *testing.T) {
+	if result := normalizeDate(""); result != "" {
+		t.Errorf("normalizeDate(\"\") = %q, want \"\"", result)
+	}
+	if result := normalizeDate("  "); result != "" {
+		t.Errorf("normalizeDate(\"  \") = %q, want \"\"", result)
+	}
+	// Invalid input returned as-is
+	if result := normalizeDate("not-a-date"); result != "not-a-date" {
+		t.Errorf("normalizeDate(\"not-a-date\") = %q, want \"not-a-date\"", result)
+	}
+}
+
+func TestNormalizeDate_LLMBugScenario(t *testing.T) {
+	// This is the exact bug: LLM calculates 1742688000000 for "2026-03-23"
+	// but that's actually 2025-03-23. With ISO dates, this can't happen.
+	result := normalizeDate("2026-03-23")
+	ms, _ := strconv.ParseInt(result, 10, 64)
+	parsed := time.UnixMilli(ms).UTC()
+
+	if parsed.Year() != 2026 {
+		t.Errorf("normalizeDate(\"2026-03-23\") resolved to year %d, want 2026", parsed.Year())
+	}
+	if parsed.Month() != time.March || parsed.Day() != 23 {
+		t.Errorf("normalizeDate(\"2026-03-23\") resolved to %s, want 2026-03-23", parsed.Format("2006-01-02"))
+	}
+}

--- a/tools.json
+++ b/tools.json
@@ -25,11 +25,11 @@
         },
         "start_date": {
           "type": "string",
-          "description": "Start date as Unix timestamp in milliseconds (13 digits). MUST be after website createdAt. For 'last X days': current_time_ms - (X * 86400000). Example: last 7 days = now - 604800000"
+          "description": "Start date. Accepts ISO 8601 date strings (e.g. '2026-03-23' or '2026-03-23T00:00:00Z') or Unix timestamps in milliseconds (13 digits). ISO dates are RECOMMENDED to avoid calculation errors. MUST be after website createdAt."
         },
         "end_date": {
           "type": "string",
-          "description": "End date as Unix timestamp in milliseconds (13 digits). Typically current timestamp. Must be after start_date"
+          "description": "End date. Accepts ISO 8601 date strings (e.g. '2026-03-23' or '2026-03-23T23:59:59Z') or Unix timestamps in milliseconds. ISO dates are RECOMMENDED. Must be after start_date."
         }
       },
       "required": ["website_id", "start_date", "end_date"]
@@ -47,11 +47,11 @@
         },
         "start_date": {
           "type": "string",
-          "description": "Start date as Unix timestamp in milliseconds (13 digits). MUST be after website createdAt date"
+          "description": "Start date. Accepts ISO 8601 date strings (e.g. '2026-03-23') or Unix timestamps in milliseconds. ISO dates are RECOMMENDED. MUST be after website createdAt."
         },
         "end_date": {
           "type": "string",
-          "description": "End date as Unix timestamp in milliseconds (13 digits). Must be after start_date"
+          "description": "End date. Accepts ISO 8601 date strings (e.g. '2026-03-23') or Unix timestamps in milliseconds. ISO dates are RECOMMENDED. Must be after start_date."
         },
         "unit": {
           "type": "string",
@@ -75,11 +75,11 @@
         },
         "start_date": {
           "type": "string",
-          "description": "Start date as Unix timestamp in milliseconds (13 digits). MUST be after website createdAt"
+          "description": "Start date. Accepts ISO 8601 date strings (e.g. '2026-03-23') or Unix timestamps in milliseconds. ISO dates are RECOMMENDED. MUST be after website createdAt."
         },
         "end_date": {
           "type": "string",
-          "description": "End date as Unix timestamp in milliseconds (13 digits). Must be after start_date"
+          "description": "End date. Accepts ISO 8601 date strings (e.g. '2026-03-23') or Unix timestamps in milliseconds. ISO dates are RECOMMENDED. Must be after start_date."
         },
         "metric_type": {
           "type": "string",


### PR DESCRIPTION
## Summary

- Adds `normalizeDate()` function that accepts both ISO 8601 date strings and Unix timestamps (backwards-compatible)
- LLMs consistently miscalculate Unix timestamps — e.g. Claude computes `1742688000000` for "2026-03-23" which is actually **2025-03-23** (off by one year), causing all stats to return 0
- With this change, LLMs can pass `"2026-03-23"` instead of computing timestamps, eliminating the error entirely

## Changes

| File | Change |
|------|--------|
| `normalize.go` | New `normalizeDate()` function — detects format (number vs ISO string) and converts |
| `normalize_test.go` | Comprehensive tests including the exact LLM bug scenario |
| `handlers.go` | 6 lines added — call `normalizeDate()` on `StartDate`/`EndDate` in 3 handlers |
| `tools.json` | Updated descriptions to recommend ISO dates |

## Supported date formats

```
"2026-03-23"                  → date only (start of day UTC)
"2026-03-23T14:30:00Z"        → UTC datetime
"2026-03-23T14:30:00+02:00"   → datetime with timezone
"1774220400000"               → existing timestamp format (unchanged)
```

## Test plan

- [ ] `go test ./... -run TestNormalize -v` passes all 6 test cases
- [ ] Existing timestamp inputs still work (backwards-compatible)
- [ ] ISO date "2026-03-23" correctly resolves to year 2026 (not 2025)
- [ ] Timezone-aware dates convert correctly to UTC
- [ ] Empty/invalid inputs handled gracefully

Closes #20