### PR TITLE
feat: add session tools (get_sessions, get_session_stats, get_session_activity)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Binaries
 umami-mcp
 umami-mcp.exe
+umami-mcp-server
+umami-mcp-server.exe
 
 llms*
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Connect your Umami Analytics to any MCP client - Claude Desktop, VS Code, Cursor
 - "What devices and browsers are my users using?"
 - "Show me the user journey - what pages do visitors typically view in sequence?"
 
+### Sessions & Replay
+
+- "How many sessions were recorded last month? List the most active ones"
+- "Walk me through what session <id> did — the pages and events in order"
+- "Which recorded sessions came from mobile in Sweden?"
+
 ### Real-time Monitoring
 
 - "How many people are on my website right now? What pages are they viewing?"
@@ -386,6 +392,9 @@ For clients that use a `command` field (Claude Desktop, Cursor, etc.):
 | `get_pageviews` | Pageview and session counts grouped by time unit |
 | `get_metrics` | Breakdown by page, referrer, browser, OS, device, country, etc. |
 | `get_active` | Current active visitor count in real-time |
+| `get_sessions` | List individual visitor sessions, with total count — the sessions session replay records |
+| `get_session_stats` | Aggregated session totals — pageviews, visitors, visits, countries, events |
+| `get_session_activity` | Ordered pageview/event timeline for a single session |
 
 ## Configuration
 

--- a/handlers.go
+++ b/handlers.go
@@ -28,7 +28,18 @@ func (s *MCPServer) execGetWebsites(args json.RawMessage) (any, *Error) {
 	return map[string]any{"content": content}, nil
 }
 
-func (s *MCPServer) execGetStats(args json.RawMessage) (any, *Error) {
+func textContent(result any) map[string]any {
+	data, _ := json.MarshalIndent(result, "", "  ")
+	return map[string]any{"content": []map[string]string{{
+		"type": "text",
+		"text": string(data),
+	}}}
+}
+
+func (s *MCPServer) dateRangeQuery(
+	args json.RawMessage, errLabel string,
+	query func(websiteID, startDate, endDate string) (any, error),
+) (any, *Error) {
 	var params struct {
 		WebsiteID string `json:"website_id"`
 		StartDate string `json:"start_date"`
@@ -43,21 +54,18 @@ func (s *MCPServer) execGetStats(args json.RawMessage) (any, *Error) {
 		return nil, &Error{Code: -32602, Message: "Invalid website_id"}
 	}
 
-	params.StartDate = normalizeDate(params.StartDate)
-	params.EndDate = normalizeDate(params.EndDate)
-
-	stats, err := s.client.GetStats(params.WebsiteID, params.StartDate, params.EndDate)
+	result, err := query(params.WebsiteID, normalizeDate(params.StartDate), normalizeDate(params.EndDate))
 	if err != nil {
-		return nil, &Error{Code: -32603, Message: fmt.Sprintf("Failed to get stats: %v", err)}
+		return nil, &Error{Code: -32603, Message: fmt.Sprintf("Failed to get %s: %v", errLabel, err)}
 	}
 
-	data, _ := json.MarshalIndent(stats, "", "  ")
-	content := []map[string]string{{
-		"type": "text",
-		"text": string(data),
-	}}
+	return textContent(result), nil
+}
 
-	return map[string]any{"content": content}, nil
+func (s *MCPServer) execGetStats(args json.RawMessage) (any, *Error) {
+	return s.dateRangeQuery(args, "stats", func(id, start, end string) (any, error) {
+		return s.client.GetStats(id, start, end)
+	})
 }
 
 func (s *MCPServer) execGetPageViews(args json.RawMessage) (any, *Error) {
@@ -156,6 +164,87 @@ func (s *MCPServer) execGetActive(args json.RawMessage) (any, *Error) {
 	}
 
 	data, _ := json.MarshalIndent(active, "", "  ")
+	content := []map[string]string{{
+		"type": "text",
+		"text": string(data),
+	}}
+
+	return map[string]any{"content": content}, nil
+}
+
+func (s *MCPServer) execGetSessions(args json.RawMessage) (any, *Error) {
+	var params struct {
+		WebsiteID string `json:"website_id"`
+		StartDate string `json:"start_date"`
+		EndDate   string `json:"end_date"`
+		Search    string `json:"search"`
+		Page      int    `json:"page"`
+		PageSize  int    `json:"page_size"`
+	}
+
+	if err := json.Unmarshal(args, &params); err != nil {
+		return nil, &Error{Code: -32602, Message: "Invalid arguments"}
+	}
+
+	if err := validateWebsiteID(params.WebsiteID); err != nil {
+		return nil, &Error{Code: -32602, Message: "Invalid website_id"}
+	}
+
+	params.StartDate = normalizeDate(params.StartDate)
+	params.EndDate = normalizeDate(params.EndDate)
+
+	sessions, err := s.client.GetSessions(
+		params.WebsiteID, params.StartDate, params.EndDate, params.Search, params.Page, params.PageSize,
+	)
+	if err != nil {
+		return nil, &Error{Code: -32603, Message: fmt.Sprintf("Failed to get sessions: %v", err)}
+	}
+
+	data, _ := json.MarshalIndent(sessions, "", "  ")
+	content := []map[string]string{{
+		"type": "text",
+		"text": string(data),
+	}}
+
+	return map[string]any{"content": content}, nil
+}
+
+func (s *MCPServer) execGetSessionStats(args json.RawMessage) (any, *Error) {
+	return s.dateRangeQuery(args, "session stats", func(id, start, end string) (any, error) {
+		return s.client.GetSessionStats(id, start, end)
+	})
+}
+
+func (s *MCPServer) execGetSessionActivity(args json.RawMessage) (any, *Error) {
+	var params struct {
+		WebsiteID string `json:"website_id"`
+		SessionID string `json:"session_id"`
+		StartDate string `json:"start_date"`
+		EndDate   string `json:"end_date"`
+	}
+
+	if err := json.Unmarshal(args, &params); err != nil {
+		return nil, &Error{Code: -32602, Message: "Invalid arguments"}
+	}
+
+	if err := validateWebsiteID(params.WebsiteID); err != nil {
+		return nil, &Error{Code: -32602, Message: "Invalid website_id"}
+	}
+	if err := validateSessionID(params.SessionID); err != nil {
+		return nil, &Error{Code: -32602, Message: "Invalid session_id"}
+	}
+
+	params.StartDate = normalizeDate(params.StartDate)
+	params.EndDate = normalizeDate(params.EndDate)
+
+	activity, err := s.client.GetSessionActivity(
+		params.WebsiteID, params.SessionID, params.StartDate, params.EndDate,
+	)
+	if err != nil {
+		return nil, &Error{Code: -32603, Message: fmt.Sprintf("Failed to get session activity: %v", err)}
+	}
+
+	data, _ := json.MarshalIndent(activity, "", "  ")
 	content := []map[string]string{{
 		"type": "text",
 		"text": string(data),

--- a/http_test.go
+++ b/http_test.go
@@ -243,16 +243,16 @@ func TestHTTP_ServerCard(t *testing.T) {
 	if err := json.Unmarshal(card["tools"], &tools); err != nil {
 		t.Fatalf("Failed to parse tools: %v", err)
 	}
-	if len(tools) != 5 {
-		t.Errorf("Expected 5 tools, got %d", len(tools))
+	if len(tools) != 8 {
+		t.Errorf("Expected 8 tools, got %d", len(tools))
 	}
 
 	var prompts []json.RawMessage
 	if err := json.Unmarshal(card["prompts"], &prompts); err != nil {
 		t.Fatalf("Failed to parse prompts: %v", err)
 	}
-	if len(prompts) != 4 {
-		t.Errorf("Expected 4 prompts, got %d", len(prompts))
+	if len(prompts) != 5 {
+		t.Errorf("Expected 5 prompts, got %d", len(prompts))
 	}
 }
 

--- a/mcp.go
+++ b/mcp.go
@@ -145,6 +145,12 @@ func (s *MCPServer) processToolCall(rawParams json.RawMessage) (any, *Error) {
 		return s.execGetMetrics(params.Arguments)
 	case "get_active":
 		return s.execGetActive(params.Arguments)
+	case "get_sessions":
+		return s.execGetSessions(params.Arguments)
+	case "get_session_stats":
+		return s.execGetSessionStats(params.Arguments)
+	case "get_session_activity":
+		return s.execGetSessionActivity(params.Arguments)
 	default:
 		return nil, &Error{Code: -32602, Message: fmt.Sprintf("Unknown tool: %s", params.Name)}
 	}
@@ -192,13 +198,23 @@ var promptTemplates = map[string]string{
 	"realtime-check": "First call get_websites to find the target website. " +
 		"Then call get_active to check the current number of active visitors. " +
 		"Report the real-time visitor count.",
+
+	"session-insights": "First call get_websites to find the target website. " +
+		"Then summarize recorded sessions over the last {days} days:\n" +
+		"- get_session_stats for the totals (sessions, pageviews, visitors, events)\n" +
+		"- get_sessions (raise page_size) to list sessions with their device, " +
+		"country, and view counts; note the total 'count'\n" +
+		"- for any notably long or active session, get_session_activity with its " +
+		"id to trace the page/event sequence\n\n" +
+		"Summarize engagement and call out standout sessions.",
 }
 
 var promptDefaults = map[string]map[string]string{
 	"analytics-report": {"days": "30"},
 	"top-pages":        {"days": "7", "limit": "10"},
-	"visitor-insights":  {"days": "30"},
-	"realtime-check":    {},
+	"visitor-insights": {"days": "30"},
+	"realtime-check":   {},
+	"session-insights": {"days": "30"},
 }
 
 func (s *MCPServer) processPromptsGet(rawParams json.RawMessage) (any, *Error) {

--- a/mcp_test.go
+++ b/mcp_test.go
@@ -55,11 +55,14 @@ func TestMCPServer_HandleToolsList(t *testing.T) {
 		t.Fatal("Tools is not []map[string]any")
 	}
 
-	if len(toolsInterface) != 5 {
-		t.Fatalf("Expected 5 tools, got %d", len(toolsInterface))
+	if len(toolsInterface) != 8 {
+		t.Fatalf("Expected 8 tools, got %d", len(toolsInterface))
 	}
 
-	expectedTools := []string{"get_websites", "get_stats", "get_pageviews", "get_metrics", "get_active"}
+	expectedTools := []string{
+		"get_websites", "get_stats", "get_pageviews", "get_metrics", "get_active",
+		"get_sessions", "get_session_stats", "get_session_activity",
+	}
 	for i, tool := range toolsInterface {
 		name, ok := tool["name"].(string)
 		if !ok {
@@ -104,8 +107,8 @@ func TestMCPServer_ToolsJSONValidity(t *testing.T) {
 		t.Fatalf("Failed to parse tools JSON: %v", err)
 	}
 
-	if len(tools) != 5 {
-		t.Fatalf("Expected 5 tools, got %d", len(tools))
+	if len(tools) != 8 {
+		t.Fatalf("Expected 8 tools, got %d", len(tools))
 	}
 
 	for i, tool := range tools {
@@ -137,11 +140,11 @@ func TestMCPServer_HandlePromptsList(t *testing.T) {
 		t.Fatal("Prompts is not []map[string]any")
 	}
 
-	if len(prompts) != 4 {
-		t.Fatalf("Expected 4 prompts, got %d", len(prompts))
+	if len(prompts) != 5 {
+		t.Fatalf("Expected 5 prompts, got %d", len(prompts))
 	}
 
-	expectedPrompts := []string{"analytics-report", "top-pages", "visitor-insights", "realtime-check"}
+	expectedPrompts := []string{"analytics-report", "top-pages", "visitor-insights", "realtime-check", "session-insights"}
 	for i, prompt := range prompts {
 		name, ok := prompt["name"].(string)
 		if !ok {

--- a/prompts.json
+++ b/prompts.json
@@ -25,5 +25,12 @@
     "name": "realtime-check",
     "description": "Check current active visitors on a website",
     "arguments": []
+  },
+  {
+    "name": "session-insights",
+    "description": "Summarize recorded visitor sessions over a period",
+    "arguments": [
+      { "name": "days", "description": "Number of days to analyze (default: 30)", "required": false }
+    ]
   }
 ]

--- a/tools.json
+++ b/tools.json
@@ -108,5 +108,89 @@
       },
       "required": ["website_id"]
     }
+  },
+  {
+    "name": "get_sessions",
+    "description": "List individual visitor sessions for a website over a date range, with pagination. Returns an object with 'data' (array of sessions, each with id, browser, os, device, country, region, city, language, screen, visits, views, firstAt, lastAt) plus 'count' (total sessions matching), 'page', and 'pageSize'. Each session id is what session replay (the recorder.js feature) records — use 'count' to see how many sessions/recordings exist, and pass a session 'id' to get_session_activity to inspect what happened in it. Check the website createdAt first; requesting before creation returns an empty list.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "website_id": {
+          "type": "string",
+          "description": "The website ID from get_websites"
+        },
+        "start_date": {
+          "type": "string",
+          "description": "Start date. Accepts ISO 8601 date strings (e.g. '2026-03-23') or Unix timestamps in milliseconds. ISO dates are RECOMMENDED. MUST be after website createdAt."
+        },
+        "end_date": {
+          "type": "string",
+          "description": "End date. Accepts ISO 8601 date strings (e.g. '2026-03-23') or Unix timestamps in milliseconds. ISO dates are RECOMMENDED. Must be after start_date."
+        },
+        "search": {
+          "type": "string",
+          "description": "Optional free-text filter (matches session fields such as country, browser, os, etc.)."
+        },
+        "page": {
+          "type": "integer",
+          "description": "Page number for pagination (1-based).",
+          "default": 1
+        },
+        "page_size": {
+          "type": "integer",
+          "description": "Sessions per page. Increase (e.g. 50-100) to retrieve more in one call.",
+          "default": 20
+        }
+      },
+      "required": ["website_id", "start_date", "end_date"]
+    }
+  },
+  {
+    "name": "get_session_stats",
+    "description": "Get aggregated session totals for a website over a date range. Returns flat numeric fields: pageviews, visitors, visits, countries, and events. Useful as a quick scope check before paging through get_sessions. Check the website createdAt first.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "website_id": {
+          "type": "string",
+          "description": "The website ID from get_websites"
+        },
+        "start_date": {
+          "type": "string",
+          "description": "Start date. Accepts ISO 8601 date strings (e.g. '2026-03-23') or Unix timestamps in milliseconds. ISO dates are RECOMMENDED. MUST be after website createdAt."
+        },
+        "end_date": {
+          "type": "string",
+          "description": "End date. Accepts ISO 8601 date strings (e.g. '2026-03-23') or Unix timestamps in milliseconds. ISO dates are RECOMMENDED. Must be after start_date."
+        }
+      },
+      "required": ["website_id", "start_date", "end_date"]
+    }
+  },
+  {
+    "name": "get_session_activity",
+    "description": "Get the ordered activity timeline (pageviews + events) for a single session, identified by a session id from get_sessions. Returns an array of entries with createdAt, urlPath, urlQuery, referrerDomain, eventType (1 = pageview, 2 = custom event), eventName, and visitId. This is the closest data-level view of what a session replay shows — the sequence of pages and actions during the visit. Optionally bound it to a time window.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "website_id": {
+          "type": "string",
+          "description": "The website ID from get_websites"
+        },
+        "session_id": {
+          "type": "string",
+          "description": "The session id from get_sessions (the 'id' field of a session)."
+        },
+        "start_date": {
+          "type": "string",
+          "description": "Optional. Start of the activity window (ISO 8601 date or Unix ms). Defaults to the beginning of time, so the whole session is returned. Pass the session's firstAt to scope tightly."
+        },
+        "end_date": {
+          "type": "string",
+          "description": "Optional. End of the activity window (ISO 8601 date or Unix ms). Defaults to now. Pass the session's lastAt to scope tightly."
+        }
+      },
+      "required": ["website_id", "session_id"]
+    }
   }
 ]

--- a/umami.go
+++ b/umami.go
@@ -297,3 +297,139 @@ func (c *UmamiClient) GetActive(websiteID string) ([]Metric, error) {
 	}
 	return metrics, nil
 }
+
+type Session struct {
+	ID        string    `json:"id"`
+	WebsiteID string    `json:"websiteId"`
+	Hostname  string    `json:"hostname"`
+	Browser   string    `json:"browser"`
+	OS        string    `json:"os"`
+	Device    string    `json:"device"`
+	Screen    string    `json:"screen"`
+	Language  string    `json:"language"`
+	Country   string    `json:"country"`
+	Region    string    `json:"region"`
+	City      string    `json:"city"`
+	FirstAt   time.Time `json:"firstAt"`
+	LastAt    time.Time `json:"lastAt"`
+	Visits    int       `json:"visits"`
+	Views     int       `json:"views"`
+	CreatedAt time.Time `json:"createdAt"`
+}
+
+type SessionList struct {
+	Data     []Session `json:"data"`
+	Count    int       `json:"count"`
+	Page     int       `json:"page"`
+	PageSize int       `json:"pageSize"`
+}
+
+func (c *UmamiClient) GetSessions(
+	websiteID, startDate, endDate, search string, page, pageSize int,
+) (*SessionList, error) {
+	params := map[string]string{
+		"startAt": startDate,
+		"endAt":   endDate,
+	}
+	if search != "" {
+		params["search"] = search
+	}
+	if page > 0 {
+		params["page"] = fmt.Sprintf("%d", page)
+	}
+	if pageSize > 0 {
+		params["pageSize"] = fmt.Sprintf("%d", pageSize)
+	}
+
+	data, err := c.doRequest(fmt.Sprintf("%s/%s/sessions", c.websitesPath(), websiteID), params)
+	if err != nil {
+		return nil, err
+	}
+
+	var result SessionList
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+type SessionStats struct {
+	PageViews int `json:"pageviews"`
+	Visitors  int `json:"visitors"`
+	Visits    int `json:"visits"`
+	Countries int `json:"countries"`
+	Events    int `json:"events"`
+}
+
+type valueField struct {
+	Value int `json:"value"`
+}
+
+func (c *UmamiClient) GetSessionStats(websiteID, startDate, endDate string) (*SessionStats, error) {
+	params := map[string]string{
+		"startAt": startDate,
+		"endAt":   endDate,
+	}
+
+	data, err := c.doRequest(fmt.Sprintf("%s/%s/sessions/stats", c.websitesPath(), websiteID), params)
+	if err != nil {
+		return nil, err
+	}
+
+	var raw struct {
+		PageViews valueField `json:"pageviews"`
+		Visitors  valueField `json:"visitors"`
+		Visits    valueField `json:"visits"`
+		Countries valueField `json:"countries"`
+		Events    valueField `json:"events"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+
+	return &SessionStats{
+		PageViews: raw.PageViews.Value,
+		Visitors:  raw.Visitors.Value,
+		Visits:    raw.Visits.Value,
+		Countries: raw.Countries.Value,
+		Events:    raw.Events.Value,
+	}, nil
+}
+
+type SessionActivity struct {
+	CreatedAt      time.Time `json:"createdAt"`
+	URLPath        string    `json:"urlPath"`
+	URLQuery       string    `json:"urlQuery"`
+	ReferrerDomain string    `json:"referrerDomain"`
+	EventID        string    `json:"eventId"`
+	EventType      int       `json:"eventType"`
+	EventName      string    `json:"eventName"`
+	VisitID        string    `json:"visitId"`
+	HasData        bool      `json:"hasData"`
+}
+
+func (c *UmamiClient) GetSessionActivity(websiteID, sessionID, startDate, endDate string) ([]SessionActivity, error) {
+	if startDate == "" {
+		startDate = "0"
+	}
+	if endDate == "" {
+		endDate = fmt.Sprintf("%d", time.Now().UnixMilli())
+	}
+	params := map[string]string{
+		"startAt": startDate,
+		"endAt":   endDate,
+	}
+
+	data, err := c.doRequest(
+		fmt.Sprintf("%s/%s/sessions/%s/activity", c.websitesPath(), websiteID, sessionID), params,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var activity []SessionActivity
+	if err := json.Unmarshal(data, &activity); err != nil {
+		return nil, err
+	}
+	return activity, nil
+}

--- a/umami_test.go
+++ b/umami_test.go
@@ -559,3 +559,108 @@ func TestUmamiClient_ErrorHandling(t *testing.T) {
 		})
 	}
 }
+
+func TestUmamiClient_GetSessions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/websites/web-1/sessions" {
+			t.Errorf("Expected path /api/websites/web-1/sessions, got %s", r.URL.Path)
+		}
+		q := r.URL.Query()
+		if q.Get("startAt") != "1000" || q.Get("endAt") != "2000" {
+			t.Errorf("Expected startAt=1000 endAt=2000, got %s/%s", q.Get("startAt"), q.Get("endAt"))
+		}
+		if q.Get("search") != "SE" {
+			t.Errorf("Expected search=SE, got %s", q.Get("search"))
+		}
+		if q.Get("pageSize") != "50" {
+			t.Errorf("Expected pageSize=50, got %s", q.Get("pageSize"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{
+				{"id": "sess-1", "browser": "chrome", "country": "SE", "views": 7},
+			},
+			"count":    407,
+			"page":     1,
+			"pageSize": 50,
+		})
+	}))
+	defer server.Close()
+
+	client := &UmamiClient{baseURL: server.URL, token: "test-token", httpClient: &http.Client{}}
+
+	result, err := client.GetSessions("web-1", "1000", "2000", "SE", 0, 50)
+	if err != nil {
+		t.Fatalf("GetSessions failed: %v", err)
+	}
+	if result.Count != 407 {
+		t.Errorf("Expected count 407, got %d", result.Count)
+	}
+	if len(result.Data) != 1 || result.Data[0].ID != "sess-1" || result.Data[0].Views != 7 {
+		t.Errorf("Unexpected session data: %+v", result.Data)
+	}
+}
+
+func TestUmamiClient_GetSessionStats(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/websites/web-1/sessions/stats" {
+			t.Errorf("Expected path /api/websites/web-1/sessions/stats, got %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"pageviews": map[string]int{"value": 3653},
+			"visitors":  map[string]int{"value": 252},
+			"visits":    map[string]int{"value": 569},
+			"countries": map[string]int{"value": 8},
+			"events":    map[string]int{"value": 12},
+		})
+	}))
+	defer server.Close()
+
+	client := &UmamiClient{baseURL: server.URL, token: "test-token", httpClient: &http.Client{}}
+
+	stats, err := client.GetSessionStats("web-1", "1000", "2000")
+	if err != nil {
+		t.Fatalf("GetSessionStats failed: %v", err)
+	}
+	if stats.PageViews != 3653 || stats.Visitors != 252 || stats.Visits != 569 ||
+		stats.Countries != 8 || stats.Events != 12 {
+		t.Errorf("Unexpected stats: %+v", stats)
+	}
+}
+
+func TestUmamiClient_GetSessionActivity(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/websites/web-1/sessions/sess-1/activity" {
+			t.Errorf("Expected path /api/websites/web-1/sessions/sess-1/activity, got %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"urlPath": "/predict", "eventType": 1, "eventName": ""},
+			{"urlPath": "/pay", "eventType": 2, "eventName": "pay-click"},
+		})
+	}))
+	defer server.Close()
+
+	client := &UmamiClient{baseURL: server.URL, token: "test-token", httpClient: &http.Client{}}
+
+	activity, err := client.GetSessionActivity("web-1", "sess-1", "", "")
+	if err != nil {
+		t.Fatalf("GetSessionActivity failed: %v", err)
+	}
+	if len(activity) != 2 || activity[0].URLPath != "/predict" || activity[1].EventName != "pay-click" {
+		t.Errorf("Unexpected activity: %+v", activity)
+	}
+}
+
+func TestValidateSessionID(t *testing.T) {
+	if err := validateSessionID("550e8400-e29b-41d4-a716-446655440000"); err != nil {
+		t.Errorf("expected valid session ID, got %v", err)
+	}
+	if err := validateSessionID("../../etc"); err == nil {
+		t.Error("expected error for path traversal session ID")
+	}
+}

--- a/validate.go
+++ b/validate.go
@@ -3,12 +3,20 @@ package main
 import "fmt"
 
 func validateWebsiteID(id string) error {
+	return validateID(id, "website ID")
+}
+
+func validateSessionID(id string) error {
+	return validateID(id, "session ID")
+}
+
+func validateID(id, label string) error {
 	if id == "" || len(id) > 36 {
-		return fmt.Errorf("invalid website ID")
+		return fmt.Errorf("invalid %s", label)
 	}
 	for _, c := range id {
 		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F') || c == '-') {
-			return fmt.Errorf("invalid website ID")
+			return fmt.Errorf("invalid %s", label)
 		}
 	}
 	return nil


### PR DESCRIPTION
## What

Adds three tools that surface Umami's **per-session** data — the sessions that Session Replay records — which the server didn't expose before:

| Tool | Endpoint | Returns |
|---|---|---|
| `get_sessions` | `GET /websites/{id}/sessions` | Paginated session list **+ total `count`**; each row has browser, os, device, country/region/city, language, screen, visits, views, firstAt/lastAt |
| `get_session_stats` | `GET /websites/{id}/sessions/stats` | Flattened totals: pageviews, visitors, visits, countries, events |
| `get_session_activity` | `GET /websites/{id}/sessions/{sessionId}/activity` | Ordered pageview/event timeline for one session |

## Why

People with Session Replay enabled can see recorded sessions in the dashboard but can't reach them through the MCP. `get_sessions` gives the count + metadata, and `get_session_activity` reconstructs the page/event sequence of a visit — the closest data-level view of what a replay shows.

## Notes

- **Activity date params:** the `/activity` endpoint returns `400 "expected number, received NaN"` when `startAt`/`endAt` are omitted on current Umami, despite the docs marking them optional. The client defaults them (`0` .. now) so the tool works out of the box; callers can still pass a session's `firstAt`/`lastAt` to scope.
- Refactored the shared *validate website_id → normalize dates → run query → render* flow into `dateRangeQuery` / `textContent` helpers; `get_stats` and `get_session_stats` now share it.
- `validateWebsiteID` generalized to `validateID`, plus `validateSessionID`.
- Added a `session-insights` prompt and README / tool-table entries.
- `.gitignore`: also ignore the default `umami-mcp-server` build artifact (the existing entries only covered `umami-mcp`).

## Testing

- `go test ./...` — pass (added client tests for all three endpoints + `validateSessionID`).
- `golangci-lint v1.64.8 run ./...` — clean.
- Verified against a live self-hosted Umami: real session count, stats, and a full page/event timeline came back correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)